### PR TITLE
파이어스토어 연동 및 프로세스 함수화

### DIFF
--- a/project-v3/functions/common-util.js
+++ b/project-v3/functions/common-util.js
@@ -102,7 +102,7 @@ const commonUtil = {
 	/**
 	 * storeImageToBucket
 	 * @param args pipe, path,type,tag
-	 * @returns {Promise<any>}
+	 * @returns {Promise<any>}, file model and image model
 	 *
 	 *
 	 */
@@ -178,6 +178,12 @@ const commonUtil = {
 				.end(body);
 		});
 	},
+	/**
+	 * isValidImage
+	 * valify image with gm library
+	 * @param args
+	 * @returns {Promise<any>}
+	 */
 	isValidImage: args => {
 		let path = args.path != undefined ? args.path : args[0];
 		let file = bucket.file(path);
@@ -193,6 +199,31 @@ const commonUtil = {
 				});
 			});
 		});
+	},
+
+	promiseSeqOneSec: promises => {
+		let oneSecFunc = (fc, args, sec) => {
+			return new Promise(resolve => {
+				setTimeout(
+					() => {
+						resolve(fc(args));
+					},
+					1000 * sec,
+					{}
+				);
+			});
+		};
+		if (promises == undefined) {
+			console.log("promises is undefined");
+			return null;
+		}
+		let processPromises = [];
+		for (let i = 0; i < promises.length; i++) {
+			processPromises.push(
+				oneSecFunc(promises[i].func, promises[i].args, i)
+			);
+		}
+		return Promise.all(processPromises);
 	}
 };
 

--- a/project-v3/functions/model/ThumbImage.js
+++ b/project-v3/functions/model/ThumbImage.js
@@ -1,0 +1,6 @@
+//파일 정보
+module.exports = function ThumbImage(thumb_idx, thumb_url, toon_info_idx) {
+	this.thumb_idx = thumb_idx;
+	this.thumb_url = thumb_url;
+	this.toon_info_idx = toon_info_idx;
+};

--- a/project-v3/functions/properties.json
+++ b/project-v3/functions/properties.json
@@ -24,6 +24,14 @@
     "bannerImage": {
       "value": "",
       "referer": "http://comic.naver.com/index.nhn"
+    },
+    "thumbImageList": {
+      "value": "http://comic.naver.com/webtoon/weekday.nhn",
+      "referer": ""
+    },
+    "thumbImage": {
+      "value": "",
+      "referer": "http://thumb.comic.naver.net/"
     }
   }
 }

--- a/project-v3/functions/service/crawlService.js
+++ b/project-v3/functions/service/crawlService.js
@@ -105,7 +105,8 @@ const self = {
 						});
 					});
 			});
-	}
+	},
+	everydayCrwalToon: () => {}
 };
 
 module.exports = self;

--- a/project-v3/functions/service/firestoreService.js
+++ b/project-v3/functions/service/firestoreService.js
@@ -1,0 +1,55 @@
+const admin = require("firebase-admin");
+const properties = require("../properties.json");
+const serviceAccount = require("../" + properties.index.serviceAccount);
+
+try {
+	admin.app();
+} catch (e) {
+	admin.initializeApp({
+		credential: admin.credential.cert(serviceAccount),
+		databaseURL: properties.admin.databaseURL,
+		storageBucket: properties.admin.storageBucket
+	});
+}
+
+const db = admin.firestore();
+
+const self = {
+	insert: insertInfo => {
+		//let insertInfo =
+		//	args.insertInfo != undefined ? args.insertInfo : args[0];
+		if (insertInfo.length == 1) {
+			return db
+				.collection(insertInfo[0].model)
+				.doc(insertInfo[0].key)
+				.set(insertInfo[0].data);
+		}
+
+		// Get a new write batch
+		const batch = db.batch();
+		for (let i = 0; i < insertInfo.length; i++) {
+			batch.set(
+				db.collection(insertInfo[i].model).doc(insertInfo[i].key),
+				insertInfo[i].data
+			);
+		}
+		return batch.commit();
+	},
+	select: model => {
+		return db
+			.collection(model)
+			.get()
+			.then(snapshot => {
+				let promises = [];
+				snapshot.forEach(doc => {
+					promises.push(doc);
+				});
+				return Promise.all(promises);
+			})
+			.then(docs => {
+				return docs.map(ele => ele.data());
+			});
+	}
+};
+
+module.exports = self;

--- a/project-v3/functions/unit-test.js
+++ b/project-v3/functions/unit-test.js
@@ -2,10 +2,7 @@ const commonUtil = require("./common-util");
 const crawlService = require("./service/crawlService");
 const imageDownloader = require("./service/imageDownloader");
 const BannerImage = require("./model/BannerImage");
-
-process.on("exit", function(code) {
-	return console.log(`About to exit with code ${code}`);
-});
+const fs = require("./service/firestoreService");
 
 const jsTester = {
 	assertResult: (caller, unitTest, args) => {
@@ -43,11 +40,21 @@ const jsTester = {
 		let testList = [];
 
 		for (var i in unitTest) {
-			if (
-				unitTest[i].name != undefined &&
-				unitTest[i].name.includes("test")
-			)
+			if (process.argv[2] == undefined) {
+				if (
+					unitTest[i].name != undefined &&
+					unitTest[i].name.includes("test")
+				)
+					testList[testList.length] = unitTest[i];
+			} else if (process.argv[2] == 1) {
 				testList[testList.length] = unitTest[i];
+			} else if (process.argv[2] == 2) {
+				if (
+					unitTest[i].name != undefined &&
+					unitTest[i].name.includes("zzzz")
+				)
+					testList[testList.length] = unitTest[i];
+			}
 		}
 
 		jsTester.testInSequence(testList);
@@ -106,7 +113,7 @@ const unitTest = {
 					return commonUtil
 						.crawlingHTMLArray([result, args[1]])
 						.then(result2 => {
-							return result2.length == 197;
+							return result2.length == 198;
 						});
 				});
 			},
@@ -153,18 +160,43 @@ const unitTest = {
 			"testRequestImage",
 			commonUtil.requestImage,
 			[
-				"http://imgcomic.naver.net/webtoon/641253/thumbnail/thumbnail_IMAG02_e046a3f5-9825-495b-a61c-fc8162fa6da4.jpg",
+				"http://imgcomic.naver.net/webtoon/641253/thumbnail/" +
+					"thumbnail_IMAG02_e046a3f5-9825-495b-a61c-fc8162fa6da4.jpg",
 				"http://comic.naver.com/index.nhn"
 			]
 		);
 	},
 	/**
-	 * testStoreImageToBucket
+	 * testCrawlBannerImage
 	 * @returns {*}
 	 */
+	testCrawlBannerImage: () => {
+		return jsTester.assertResult(
+			"testCrawlBannerImage",
+			args => {
+				return imageDownloader.crawlBannerImage().then(result => {
+					// console.log(result);
+					return true;
+				});
+			},
+			[]
+		);
+	},
+
+	testCrawlThumbImage: () => {
+		return jsTester.assertResult(
+			"testCrawlThumbImage",
+			() => {
+				return imageDownloader.crawlThumbImage().then(result => {
+					return result.length == 198;
+				});
+			},
+			[]
+		);
+	},
 	StoreImageToBucket: () => {
 		return jsTester.assertResult(
-			"testStoreImageToBucket",
+			"StoreImageToBucket",
 			args => {
 				return commonUtil
 					.requestImage([args[0], args[1]])
@@ -198,53 +230,75 @@ const unitTest = {
 					});
 			},
 			[
-				"http://imgcomic.naver.net/webtoon/641253/thumbnail/thumbnail_IMAG02_e046a3f5-9825-495b-a61c-fc8162fa6da4.jpg",
+				"http://imgcomic.naver.net/webtoon/641253/thumbnail/" +
+					"thumbnail_IMAG02_e046a3f5-9825-495b-a61c-fc8162fa6da4.jpg",
 				"http://comic.naver.com/index.nhn",
 				"/test/"
 			]
 		);
 	},
-	/**
-	 * testCrawlBannerImage
-	 * @returns {*}
-	 */
-	testCrawlBannerImage: () => {
-		return jsTester.assertResult(
-			"testCrawlBannerImage",
-			args => {
-				return imageDownloader.crawlBannerImage().then(result => {
-					// console.log(result);
-					return true;
-				});
-			},
-			[]
-		);
-	},
 	DownloadBannerImage: () => {
 		let bannerImage = new BannerImage(
 			"20180427027",
-			"http://imgcomic.naver.net/webtoon/710649/thumbnail/thumbnail_IMAG02_7956ae54-647e-4ff2-9d69-91241c6bdb31.jpg",
+			"http://imgcomic.naver.net/webtoon/710649/thumbnail/" +
+				"thumbnail_IMAG02_7956ae54-647e-4ff2-9d69-91241c6bdb31.jpg",
 			"710649"
 		);
 		return jsTester.assertResult(
-			"testDownloadBannerImage",
+			"DownloadBannerImage",
 			args => {
 				return imageDownloader.crawlBannerImage().then(result => {
 					return imageDownloader.downloadBannerImage([result[0]]);
 				});
-			},
+			},g
 			[]
+		);
+	},
+
+	FirestoreInsert: () => {
+		return jsTester.assertResult(
+			"FirestoreInsert",
+			args => {
+				return fs
+					.insert(args)
+					.then(() => {
+						return fs.select(args[0].model);
+					})
+					.then(result => {
+						for (i in result)
+							if (result[i].value != 10 && result.length != 2)
+								return false;
+						return true;
+					});
+			},
+			[
+				{
+					model: "test",
+					key: "1",
+					data: {
+						value: 10
+					}
+				},
+				{
+					model: "test",
+					key: "2",
+					data: {
+						value: 10
+					}
+				}
+			]
 		);
 	},
 	DownloadBannerImageList: () => {
 		return jsTester.assertResult(
-			"testDownloadBannerImageList",
+			"DownloadBannerImageList",
 			args => {
 				return imageDownloader
 					.crawlBannerImage()
 					.then(result => {
-						return imageDownloader.downloadBannerImageList([
-							result
+						return imageDownloader.downloadImageList([
+							result,
+							imageDownloader.downloadBannerImage
 						]);
 					})
 					.then(result2 => {
@@ -252,6 +306,65 @@ const unitTest = {
 					});
 			},
 			[]
+		);
+	},
+	DownloadThumbImageList: () => {
+		return jsTester.assertResult(
+			"DownloadThumbImageList",
+			args => {
+				return imageDownloader
+					.crawlThumbImage()
+					.then(result => {
+						return imageDownloader.downloadImageList([
+							result,
+							imageDownloader.downloadThumbImage
+						]);
+					})
+					.then(result2 => {
+						console.log(result2);
+						return result2;
+					});
+			},
+			[]
+		);
+	},
+	testPromiseSeqOneSec: () => {
+		return jsTester.assertResult(
+			"testPromiseSeqOneSec",
+			args => {
+				return commonUtil.promiseSeqOneSec(args).then(result => {
+					return true;
+				});
+			},
+			[
+				{
+					func: a => {
+						return new Promise(resolve => {
+							console.log(a);
+							resolve(a);
+						});
+					},
+					args: 1
+				},
+				{
+					func: a => {
+						return new Promise(resolve => {
+							console.log(a);
+							resolve(a);
+						});
+					},
+					args: 2
+				},
+				{
+					func: a => {
+						return new Promise(resolve => {
+							console.log(a);
+							resolve(a);
+						});
+					},
+					args: 3
+				}
+			]
 		);
 	}
 };


### PR DESCRIPTION
feat(firestore) && feat(promiseRequest)
1. firestore insert and select
2. crawling request each one second

썸네일 크롤링의 경우 한번에 198개 이미지를 요청하는 부분이 과부하를 유발합니다.
프로미스와 settimeout을 활용하여 각 크롤링 요청은 1초에 한번씩 하는 방법으로 구현하여
네이버 웹툰 서비스에 과부화를 주지 않습니다.